### PR TITLE
add ISteamFriends.GetPersonaName method

### DIFF
--- a/steamworks.go
+++ b/steamworks.go
@@ -80,6 +80,10 @@ type ISteamUtils interface {
 	ShowFloatingGamepadTextInput(keyboardMode EFloatingGamepadTextInputMode, textFieldXPosition, textFieldYPosition, textFieldWidth, textFieldHeight int32) bool
 }
 
+type ISteamFriends interface {
+	GetPersonaName() string
+}
+
 const (
 	flatAPI_RestartAppIfNecessary = "SteamAPI_RestartAppIfNecessary"
 	flatAPI_Init                  = "SteamAPI_Init"
@@ -88,6 +92,9 @@ const (
 	flatAPI_SteamApps                         = "SteamAPI_SteamApps_v008"
 	flatAPI_ISteamApps_GetAppInstallDir       = "SteamAPI_ISteamApps_GetAppInstallDir"
 	flatAPI_ISteamApps_GetCurrentGameLanguage = "SteamAPI_ISteamApps_GetCurrentGameLanguage"
+
+	flagAPI_SteamFriends                 = "SteamAPI_SteamFriends_v017"
+	flatAPI_ISteamFriends_GetPersonaName = "SteamAPI_ISteamFriends_GetPersonaName"
 
 	flatAPI_SteamInput                          = "SteamAPI_SteamInput_v006"
 	flatAPI_ISteamInput_GetConnectedControllers = "SteamAPI_ISteamInput_GetConnectedControllers"

--- a/steamworks_unix.go
+++ b/steamworks_unix.go
@@ -281,6 +281,24 @@ func (s steamApps) GetCurrentGameLanguage() string {
 	return C.GoString(C.uintptrToChar(C.uintptr_t(v)))
 }
 
+func SteamFriends() ISteamFriends {
+	v, err := theLib.call(funcType_Ptr, flagAPI_SteamFriends)
+	if err != nil {
+		panic(err)
+	}
+	return steamFriends(v)
+}
+
+type steamFriends C.uintptr_t
+
+func (s steamFriends) GetPersonaName() string {
+	v, err := theLib.call(funcType_Ptr_Ptr, flatAPI_ISteamFriends_GetPersonaName, uintptr(s))
+	if err != nil {
+		panic(err)
+	}
+	return C.GoString(C.uintptrToChar(C.uintptr_t(v)))
+}
+
 func SteamInput() ISteamInput {
 	v, err := theLib.call(funcType_Ptr, flatAPI_SteamInput)
 	if err != nil {


### PR DESCRIPTION
This method is useful to find out the current player's display name.

----

Tested on Linux and Windows.