### PR TITLE
Don't try to build steamworks for android or ios

### DIFF
--- a/steamworks_unix.go
+++ b/steamworks_unix.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2021 The go-steamworks Authors
 
-//go:build !windows !android !ios
+//go:build (!windows && !android && !ios)
 
 package steamworks
 

--- a/steamworks_unix.go
+++ b/steamworks_unix.go
@@ -2,6 +2,8 @@
 // SPDX-FileCopyrightText: 2021 The go-steamworks Authors
 
 //go:build !windows
+//go:build !android
+//go:build !ios
 
 package steamworks
 

--- a/steamworks_unix.go
+++ b/steamworks_unix.go
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2021 The go-steamworks Authors
 
-//go:build !windows
-//go:build !android
-//go:build !ios
+//go:build !windows !android !ios
 
 package steamworks
 


### PR DESCRIPTION
It doesn't work on those platforms, and currently the build is broken. Adding this build tag fixes it.