### PR TITLE
Add leaderboard api

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,27 @@ func SystemLang() language.Tag {
 	}
 	return language.Und
 }
+
+func Leaderboards(){
+	successFunc := func(entry LeaderboardEntry_t, entryIndex, entryCount int, details ...int32) {
+		if entryCount == 0 {
+			fmt.Println("no entry")
+		} else {
+			fmt.Printf("entry:%+v\n", entry)
+		}
+	}
+	timeoutFunc := func(readTime time.Time, readSpend time.Duration) {
+		fmt.Println("read leaderbord timeout,spend time:", readSpend)
+	}
+	// read leadboard info
+	SteamUserStats().ReadLeadboard("your leadboard name", ELeaderboardDataRequestGlobal, 0, 10, successFunc, timeoutFunc, 0)
+
+	uploadRetFunc := func(ret LeaderboardScoreUploaded_t) {
+		fmt.Printf("%+v\n", ret)
+	}
+	// upload leadboard
+	SteamUserStats().UploadLeaderboardScore("your leadboard name", ELeaderboardUploadScoreMethod_KeepBest, uploadRetFunc, timeoutFunc, 50)
+}
 ```
 
 ## License

--- a/callback.go
+++ b/callback.go
@@ -1,0 +1,115 @@
+package steamworks
+
+import (
+	"sync"
+	"time"
+)
+
+var interval time.Duration = 20 * time.Millisecond
+var timeout time.Duration = 10 * time.Second
+
+type iCallbackExpected int
+
+const (
+	iCallbackExpected_LeaderboardFindResult_t       iCallbackExpected = 1104
+	iCallbackExpected_LeaderboardScoresDownloaded_t iCallbackExpected = 1105
+	iCallbackExpected_LeaderboardScoreUploaded_t    iCallbackExpected = 1106
+)
+
+type callbackClient struct {
+	timeout          time.Duration
+	interval         time.Duration
+	intervalTimer    *time.Timer
+	steamUtils       ISteamUtils
+	callbackArgsWait []*CallbackArgs
+	callbackArgsChan chan *CallbackArgs
+	closeSignal      chan bool
+}
+type CallbackArgs struct {
+	CallbackAPI      SteamAPICall_t
+	CallbackExpected iCallbackExpected
+	CallbaseSize     int
+	SuccessFunc      callbackSuccessFunc
+	TimeoutFunc      callbackTimeoutFunc
+
+	beginTime time.Time
+}
+
+type callbackSuccessFunc func(ret []byte)
+type callbackTimeoutFunc func(callbackTime time.Time, callbackSpend time.Duration)
+
+var callbackCli *callbackClient
+var callbackOnce sync.Once
+
+func defaultCallbackCli() *callbackClient {
+	callbackOnce.Do(func() {
+		callbackCli = &callbackClient{
+			timeout:          timeout,
+			interval:         interval,
+			intervalTimer:    time.NewTimer(interval),
+			steamUtils:       SteamUtils(),
+			callbackArgsWait: make([]*CallbackArgs, 0),
+			callbackArgsChan: make(chan *CallbackArgs, 10),
+			closeSignal:      make(chan bool, 1),
+		}
+	})
+	go callbackCli.run()
+	return callbackCli
+}
+
+func (c *callbackClient) setCallback(callbackArgs *CallbackArgs) {
+	callbackArgs.beginTime = time.Now()
+	c.callbackArgsChan <- callbackArgs
+}
+
+func (c *callbackClient) run() {
+	defer close(c.callbackArgsChan)
+	defer close(c.closeSignal)
+	for {
+		<-c.intervalTimer.C
+		select {
+		case arg := <-c.callbackArgsChan:
+			c.callbackArgsWait = append(c.callbackArgsWait, arg)
+		default:
+			if len(c.callbackArgsWait) == 0 {
+				c.intervalTimer.Stop()
+				if !c.waitArgs() {
+					return
+				}
+			}
+			RunCallbacks()
+			for i := 0; i < len(c.callbackArgsWait); {
+				a := c.callbackArgsWait[i]
+				spend := time.Since(a.beginTime)
+				if spend > c.timeout {
+					a.TimeoutFunc(a.beginTime, spend)
+					c.callbackArgsWait = append(c.callbackArgsWait[:i], c.callbackArgsWait[i+1:]...)
+					continue
+				}
+				call, ok, fail := c.steamUtils.GetAPICallResult(a.CallbackAPI, a.CallbackExpected, a.CallbaseSize)
+				if ok && !fail {
+					a.SuccessFunc(call)
+					c.callbackArgsWait = append(c.callbackArgsWait[:i], c.callbackArgsWait[i+1:]...)
+					continue
+				}
+				i++
+			}
+		}
+		c.intervalTimer.Reset(c.interval)
+	}
+
+}
+
+func (c *callbackClient) waitArgs() bool {
+	select {
+	case arg := <-c.callbackArgsChan:
+		c.callbackArgsWait = append(c.callbackArgsWait, arg)
+		return true
+	case <-c.closeSignal:
+		return false
+	}
+}
+
+func (c *callbackClient) close() {
+	c.closeSignal <- true
+}

--- a/callback.go
+++ b/callback.go
@@ -65,6 +65,7 @@ func (c *callbackClient) setCallback(callbackArgs *CallbackArgs) {
 func (c *callbackClient) run() {
 	defer close(c.callbackArgsChan)
 	defer close(c.closeSignal)
+	defer c.intervalTimer.Stop()
 	for {
 		<-c.intervalTimer.C
 		select {

--- a/steamworks.go
+++ b/steamworks.go
@@ -8,8 +8,11 @@ package steamworks
 type AppId_t uint32
 type CSteamID uint64
 type InputHandle_t uint64
-
+type SteamAPICall_t uint64
+type SteamLeaderboard_t uint64
 type ESteamAPIInitResult int32
+type SteamLeaderboardEntries_t uint64
+type UGCHandle_t uint64
 
 const (
 	ESteamAPIInitResult_OK              ESteamAPIInitResult = 0
@@ -53,6 +56,40 @@ const (
 	EFloatingGamepadTextInputMode_ModeNumeric       EFloatingGamepadTextInputMode = 3
 )
 
+type ELeaderboardDisplayType int32
+
+const (
+	ELeaderboardDisplayType_None             ELeaderboardDisplayType = 0
+	ELeaderboardDisplayType_Numeric          ELeaderboardDisplayType = 1
+	ELeaderboardDisplayType_TimeSeconds      ELeaderboardDisplayType = 2
+	ELeaderboardDisplayType_TimeMilliSeconds ELeaderboardDisplayType = 3
+)
+
+type ELeaderboardSortMethod int32
+
+const (
+	ELeaderboardSortMethod_None       ELeaderboardSortMethod = 0
+	ELeaderboardSortMethod_Ascending  ELeaderboardSortMethod = 1
+	ELeaderboardSortMethod_Descending ELeaderboardSortMethod = 2
+)
+
+type ELeaderboardDataRequest int32
+
+const (
+	ELeaderboardDataRequestGlobal           ELeaderboardDataRequest = 0
+	ELeaderboardDataRequestGlobalAroundUser ELeaderboardDataRequest = 1
+	ELeaderboardDataRequestFriends          ELeaderboardDataRequest = 2
+	ELeaderboardDataRequestUsers            ELeaderboardDataRequest = 3
+)
+
+type ELeaderboardUploadScoreMethod int32
+
+const (
+	ELeaderboardUploadScoreMethod_None        ELeaderboardUploadScoreMethod = 0
+	ELeaderboardUploadScoreMethod_KeepBest    ELeaderboardUploadScoreMethod = 1
+	ELeaderboardUploadScoreMethod_ForceUpdate ELeaderboardUploadScoreMethod = 2
+)
+
 type ISteamApps interface {
 	BGetDLCDataByIndex(iDLC int) (appID AppId_t, available bool, pchName string, success bool)
 	BIsDlcInstalled(appID AppId_t) bool
@@ -84,11 +121,16 @@ type ISteamUserStats interface {
 	SetAchievement(name string) bool
 	ClearAchievement(name string) bool
 	StoreStats() bool
+
+	// Leaderboard
+	ReadLeadboard(leaderboardName string, dataRequest ELeaderboardDataRequest, rangeStart, rangeEnd int, successFunc DealLeaderboardFunc, timeoutFunc ReadTimeoutFunc, detailsMax int)
+	UploadLeaderboardScore(leaderboardName string, uploadScoreMethod ELeaderboardUploadScoreMethod, retFunc UploadRetFunc, timeoutFunc ReadTimeoutFunc, score int32, scoreDetails ...int32)
 }
 
 type ISteamUtils interface {
 	IsSteamRunningOnSteamDeck() bool
 	ShowFloatingGamepadTextInput(keyboardMode EFloatingGamepadTextInputMode, textFieldXPosition, textFieldYPosition, textFieldWidth, textFieldHeight int32) bool
+	GetAPICallResult(apiCall SteamAPICall_t, callbackExpected iCallbackExpected, callbaseSize int) (callback []byte, success bool, pbFailed bool)
 }
 
 type ISteamFriends interface {
@@ -127,15 +169,21 @@ const (
 	flatAPI_SteamUser             = "SteamAPI_SteamUser_v023"
 	flatAPI_ISteamUser_GetSteamID = "SteamAPI_ISteamUser_GetSteamID"
 
-	flatAPI_SteamUserStats                   = "SteamAPI_SteamUserStats_v013"
-	flatAPI_ISteamUserStats_GetAchievement   = "SteamAPI_ISteamUserStats_GetAchievement"
-	flatAPI_ISteamUserStats_SetAchievement   = "SteamAPI_ISteamUserStats_SetAchievement"
-	flatAPI_ISteamUserStats_ClearAchievement = "SteamAPI_ISteamUserStats_ClearAchievement"
-	flatAPI_ISteamUserStats_StoreStats       = "SteamAPI_ISteamUserStats_StoreStats"
+	flatAPI_SteamUserStats                                = "SteamAPI_SteamUserStats_v013"
+	flatAPI_ISteamUserStats_GetAchievement                = "SteamAPI_ISteamUserStats_GetAchievement"
+	flatAPI_ISteamUserStats_SetAchievement                = "SteamAPI_ISteamUserStats_SetAchievement"
+	flatAPI_ISteamUserStats_ClearAchievement              = "SteamAPI_ISteamUserStats_ClearAchievement"
+	flatAPI_ISteamUserStats_StoreStats                    = "SteamAPI_ISteamUserStats_StoreStats"
+	flatAPI_ISteamUserStats_FindLeaderboard               = "SteamAPI_ISteamUserStats_FindLeaderboard"
+	flatAPI_ISteamUserStats_GetLeaderboardName            = "SteamAPI_ISteamUserStats_GetLeaderboardName"
+	flatAPI_ISteamUserStats_DownloadLeaderboardEntries    = "SteamAPI_ISteamUserStats_DownloadLeaderboardEntries"
+	flatAPI_ISteamUserStats_UploadLeaderboardScore        = "SteamAPI_ISteamUserStats_UploadLeaderboardScore"
+	flatAPI_ISteamUserStats_GetDownloadedLeaderboardEntry = "SteamAPI_ISteamUserStats_GetDownloadedLeaderboardEntry"
 
 	flatAPI_SteamUtils                               = "SteamAPI_SteamUtils_v010"
 	flatAPI_ISteamUtils_IsSteamRunningOnSteamDeck    = "SteamAPI_ISteamUtils_IsSteamRunningOnSteamDeck"
 	flatAPI_ISteamUtils_ShowFloatingGamepadTextInput = "SteamAPI_ISteamUtils_ShowFloatingGamepadTextInput"
+	flatAPI_ISteamUtils_GetAPICallResult             = "SteamAPI_ISteamUtils_GetAPICallResult"
 )
 
 type steamErrMsg [1024]byte

--- a/struct.go
+++ b/struct.go
@@ -1,0 +1,154 @@
+package steamworks
+
+import (
+	"reflect"
+	"unsafe"
+)
+
+/*
+typedef unsigned long long int SteamLeaderboard_t;
+typedef unsigned long long int SteamLeaderboardEntries_t;
+typedef unsigned char uint8;
+
+typedef struct {
+	unsigned long int m_steamIDUser;
+	int m_nGlobalRank;
+	int m_nScore;
+	int m_cDetails;
+	unsigned long int m_hUGC;
+} LeaderboardEntry_t;
+
+typedef struct {
+	SteamLeaderboard_t m_hSteamLeaderboard;
+	uint8 m_bLeaderboardFound;
+}LeaderboardFindResult_t;
+
+typedef struct{
+	SteamLeaderboard_t m_hSteamLeaderboard;
+	SteamLeaderboardEntries_t m_hSteamLeaderboardEntries;
+	int m_cEntryCount;
+}LeaderboardScoresDownloaded_t;
+
+typedef struct{
+	uint8 m_bSuccess;
+	SteamLeaderboard_t m_hSteamLeaderboard;
+	int m_nScore;
+	uint8 m_bScoreChanged;
+	int m_nGlobalRankNew;
+	int m_nGlobalRankPrevious;
+}LeaderboardScoreUploaded_t;
+*/
+import "C"
+
+type IStruct interface {
+	Size() uintptr
+	CStructPtr() uintptr
+}
+
+type LeaderboardScoreUploaded_t struct {
+	Success            bool
+	SteamLeaderboard   SteamLeaderboard_t
+	Score              int
+	ScoreChanged       bool
+	GlobalRankNew      int
+	GlobalRankPrevious int
+}
+
+func (l LeaderboardScoreUploaded_t) FromCStruct(cstruct C.LeaderboardScoreUploaded_t) LeaderboardScoreUploaded_t {
+	return LeaderboardScoreUploaded_t{
+		Success:            cstruct.m_bSuccess != 0,
+		SteamLeaderboard:   SteamLeaderboard_t(cstruct.m_hSteamLeaderboard),
+		Score:              int(cstruct.m_nScore),
+		ScoreChanged:       cstruct.m_bScoreChanged != 0,
+		GlobalRankNew:      int(cstruct.m_nGlobalRankNew),
+		GlobalRankPrevious: int(cstruct.m_nGlobalRankPrevious),
+	}
+}
+
+func (l LeaderboardScoreUploaded_t) FromByte(b []byte) LeaderboardScoreUploaded_t {
+	return l.FromCStruct(**(**C.LeaderboardScoreUploaded_t)(unsafe.Pointer(&b)))
+}
+
+func (l LeaderboardScoreUploaded_t) CStruct() C.LeaderboardScoreUploaded_t {
+	return C.LeaderboardScoreUploaded_t{}
+}
+
+func (l LeaderboardScoreUploaded_t) Size() uintptr {
+	return reflect.TypeOf(l.CStruct()).Size()
+}
+
+type LeaderboardScoresDownloaded_t struct {
+	SteamLeaderboard        SteamLeaderboard_t
+	SteamLeaderboardEntries SteamLeaderboardEntries_t
+	EntryCount              int
+}
+
+func (l LeaderboardScoresDownloaded_t) FromCStruct(cstruct C.LeaderboardScoresDownloaded_t) LeaderboardScoresDownloaded_t {
+	return LeaderboardScoresDownloaded_t{
+		SteamLeaderboard:        SteamLeaderboard_t(cstruct.m_hSteamLeaderboard),
+		SteamLeaderboardEntries: SteamLeaderboardEntries_t(cstruct.m_hSteamLeaderboardEntries),
+		EntryCount:              int(cstruct.m_cEntryCount),
+	}
+}
+
+func (l LeaderboardScoresDownloaded_t) FromByte(b []byte) LeaderboardScoresDownloaded_t {
+	return l.FromCStruct(**(**C.LeaderboardScoresDownloaded_t)(unsafe.Pointer(&b)))
+}
+
+func (l LeaderboardScoresDownloaded_t) CStruct() C.LeaderboardScoresDownloaded_t {
+	return C.LeaderboardScoresDownloaded_t{}
+}
+
+func (l LeaderboardScoresDownloaded_t) Size() uintptr {
+	return reflect.TypeOf(l.CStruct()).Size()
+}
+
+type LeaderboardFindResult_t struct {
+	SteamLeaderboard SteamLeaderboard_t
+	LeaderboardFound bool
+}
+
+func (l LeaderboardFindResult_t) FromByte(b []byte) LeaderboardFindResult_t {
+	return l.FromCStruct(**(**C.LeaderboardFindResult_t)(unsafe.Pointer(&b)))
+}
+
+func (l LeaderboardFindResult_t) FromCStruct(cstruct C.LeaderboardFindResult_t) LeaderboardFindResult_t {
+	return LeaderboardFindResult_t{
+		SteamLeaderboard: SteamLeaderboard_t(cstruct.m_hSteamLeaderboard),
+		LeaderboardFound: cstruct.m_bLeaderboardFound != 0,
+	}
+}
+
+func (l LeaderboardFindResult_t) CStruct() C.LeaderboardFindResult_t {
+	return C.LeaderboardFindResult_t{}
+}
+
+func (l LeaderboardFindResult_t) Size() uintptr {
+	return reflect.TypeOf(l.CStruct()).Size()
+}
+
+type LeaderboardEntry_t struct {
+	SteamIDUser CSteamID
+	GlobalRank  int
+	Score       int
+	Details     int
+	UGC         UGCHandle_t
+}
+
+func (l LeaderboardEntry_t) FromCStruct(cstruct C.LeaderboardEntry_t) LeaderboardEntry_t {
+	return LeaderboardEntry_t{
+		SteamIDUser: CSteamID(cstruct.m_steamIDUser),
+		GlobalRank:  int(cstruct.m_nGlobalRank),
+		Score:       int(cstruct.m_nScore),
+		Details:     int(cstruct.m_cDetails),
+		UGC:         UGCHandle_t(cstruct.m_hUGC),
+	}
+}
+
+func (l LeaderboardEntry_t) CStruct() C.LeaderboardEntry_t {
+	return C.LeaderboardEntry_t{}
+}
+
+func (l LeaderboardEntry_t) Size() uintptr {
+	return reflect.TypeOf(l.CStruct()).Size()
+}


### PR DESCRIPTION
Add leaderboard API
1. The leaderboard interface can be viewed from the following link
[https://partner.steamgames.com/doc/api/ISteamUserStats](url)
2. This PR contains the following APIs:
```go
// read leadboard entrys
SteamUserStats().ReadLeadboard(leaderboardName string, dataRequest ELeaderboardDataRequest, rangeStart, rangeEnd int, successFunc DealLeaderboardFunc, timeoutFunc ReadTimeoutFunc, detailsMax int)
// Upload Leaderboard Score
SteamUserStats().UploadLeaderboardScore(leaderboardName string, uploadScoreMethod ELeaderboardUploadScoreMethod, retFunc UploadRetFunc, timeoutFunc ReadTimeoutFunc, score int32, scoreDetails ...int32)

// get SteamAPICall_t result
SteamUtils().GetAPICallResult(apiCall SteamAPICall_t, callbackExpected iCallbackExpected, callbaseSize int) (callback []byte, success bool, pbFailed bool)
```
4. The `ReadLeadboard `API encapsulates the following APIs in the steam SDK
    - [FindLeaderboard](https://partner.steamgames.com/doc/api/ISteamUserStats#FindLeaderboard)
    - [DownloadLeaderboardEntries](https://partner.steamgames.com/doc/api/ISteamUserStats#DownloadLeaderboardEntries)
    - [GetDownloadedLeaderboardEntry](https://partner.steamgames.com/doc/api/ISteamUserStats#GetDownloadedLeaderboardEntry)
5. The `UploadLeaderboardScore`API encapsulates the following APIs in the steam SDK
    - [FindLeaderboard](https://partner.steamgames.com/doc/api/ISteamUserStats#FindLeaderboard)
    - [UploadLeaderboardScore](https://partner.steamgames.com/doc/api/ISteamUserStats#UploadLeaderboardScore)
6. Since [FindLeaderboard](https://partner.steamgames.com/doc/api/ISteamUserStats#FindLeaderboard), [UploadLeaderboardScore](https://partner.steamgames.com/doc/api/ISteamUserStats#UploadLeaderboardScore), and [DownloadLeaderboardEntries](https://partner.steamgames.com/doc/api/ISteamUserStats#DownloadLeaderboardEntries) return [SteamAPICall_t](https://partner.steamgames.com/doc/api/steam_api#SteamAPICall_t) callback types, this PR implements an automatic callback function in callback.go to help handle asynchronous callbacks from steam

```mermaid
stateDiagram-v2
	[*] --> SetCallBack
	[*] --> close()
    SetCallBack --> RunCallbacks()
    RunCallbacks() --> runSuccessFunc(): Has Result
	RunCallbacks() --> checkTasksTimeout: No result
	checkTasksTimeout --> runTimeoutFunc(): Timeout
	checkTasksTimeout --> sleepInterval: No Timeout
	sleepInterval --> RunCallbacks()
	runTimeoutFunc() --> checkTasks
	runSuccessFunc() --> checkTasks
	checkTasks --> Pause: No Task
	checkTasks --> RunCallbacks():Has Task
	close() --> freeMem
	freeMem --> Pause
	Pause --> [*]
```
