### PR TITLE
Support 64-bit values on 386 GOARCH, To Fix Bug There With GetInputTypeForHandle()

### DIFF
--- a/steamworks_unix.go
+++ b/steamworks_unix.go
@@ -141,7 +141,7 @@ const (
 	funcType_Void_Ptr_Bool
 )
 
-func (l *lib) call(ftype funcType, name string, args ...uintptr) (C.uint64_t, error) {
+func (l *lib) call(ftype funcType, name string, args ...uint64) (C.uint64_t, error) {
 	if l.procs == nil {
 		l.procs = map[string]C.uintptr_t{}
 	}
@@ -247,7 +247,7 @@ func cBool(x bool) uintptr {
 }
 
 func RestartAppIfNecessary(appID uint32) bool {
-	v, err := theLib.call(funcType_Bool_Int32, flatAPI_RestartAppIfNecessary, uintptr(appID))
+	v, err := theLib.call(funcType_Bool_Int32, flatAPI_RestartAppIfNecessary, uint64(appID))
 	if err != nil {
 		panic(err)
 	}
@@ -256,7 +256,7 @@ func RestartAppIfNecessary(appID uint32) bool {
 
 func Init() error {
 	var msg steamErrMsg
-	v, err := theLib.call(funcType_Bool_Ptr, flatAPI_InitFlat, uintptr(unsafe.Pointer(&msg)))
+	v, err := theLib.call(funcType_Bool_Ptr, flatAPI_InitFlat, uint64(uintptr(unsafe.Pointer(&msg))))
 	if err != nil {
 		panic(err)
 	}
@@ -284,7 +284,7 @@ type steamApps C.uintptr_t
 
 func (s steamApps) BGetDLCDataByIndex(iDLC int) (appID AppId_t, available bool, pchName string, success bool) {
 	var name [4096]byte
-	v, err := theLib.call(funcType_Int32_Ptr_Int32_Ptr_Ptr_Ptr_Int32, flatAPI_ISteamApps_BGetDLCDataByIndex, uintptr(s), uintptr(iDLC), uintptr(unsafe.Pointer(&appID)), uintptr(unsafe.Pointer(&available)), uintptr(unsafe.Pointer(&name[0])), uintptr(len(name)))
+	v, err := theLib.call(funcType_Int32_Ptr_Int32_Ptr_Ptr_Ptr_Int32, flatAPI_ISteamApps_BGetDLCDataByIndex, uint64(s), uint64(iDLC), uint64(uintptr(unsafe.Pointer(&appID))), uint64(uintptr(unsafe.Pointer(&available))), uint64(uintptr(unsafe.Pointer(&name[0]))), uint64(len(name)))
 	if err != nil {
 		panic(err)
 	}
@@ -292,7 +292,7 @@ func (s steamApps) BGetDLCDataByIndex(iDLC int) (appID AppId_t, available bool, 
 }
 
 func (s steamApps) BIsDlcInstalled(appID AppId_t) bool {
-	v, err := theLib.call(funcType_Bool_Ptr_Int32, flatAPI_ISteamApps_BIsDlcInstalled, uintptr(s), uintptr(appID))
+	v, err := theLib.call(funcType_Bool_Ptr_Int32, flatAPI_ISteamApps_BIsDlcInstalled, uint64(s), uint64(appID))
 	if err != nil {
 		panic(err)
 	}
@@ -301,7 +301,7 @@ func (s steamApps) BIsDlcInstalled(appID AppId_t) bool {
 
 func (s steamApps) GetAppInstallDir(appID AppId_t) string {
 	var path [4096]byte
-	v, err := theLib.call(funcType_Int32_Ptr_Int32_Ptr_Int32, flatAPI_ISteamApps_GetAppInstallDir, uintptr(s), uintptr(appID), uintptr(unsafe.Pointer(&path[0])), uintptr(len(path)))
+	v, err := theLib.call(funcType_Int32_Ptr_Int32_Ptr_Int32, flatAPI_ISteamApps_GetAppInstallDir, uint64(s), uint64(appID), uint64(uintptr(unsafe.Pointer(&path[0]))), uint64(len(path)))
 	if err != nil {
 		panic(err)
 	}
@@ -312,7 +312,7 @@ func (s steamApps) GetAppInstallDir(appID AppId_t) string {
 }
 
 func (s steamApps) GetCurrentGameLanguage() string {
-	v, err := theLib.call(funcType_Ptr_Ptr, flatAPI_ISteamApps_GetCurrentGameLanguage, uintptr(s))
+	v, err := theLib.call(funcType_Ptr_Ptr, flatAPI_ISteamApps_GetCurrentGameLanguage, uint64(s))
 	if err != nil {
 		panic(err)
 	}
@@ -320,7 +320,7 @@ func (s steamApps) GetCurrentGameLanguage() string {
 }
 
 func (s steamApps) GetDLCCount() int32 {
-	v, err := theLib.call(funcType_Int32_Ptr, flatAPI_ISteamApps_GetDLCCount, uintptr(s))
+	v, err := theLib.call(funcType_Int32_Ptr, flatAPI_ISteamApps_GetDLCCount, uint64(s))
 	if err != nil {
 		panic(err)
 	}
@@ -338,7 +338,7 @@ func SteamFriends() ISteamFriends {
 type steamFriends C.uintptr_t
 
 func (s steamFriends) GetPersonaName() string {
-	v, err := theLib.call(funcType_Ptr_Ptr, flatAPI_ISteamFriends_GetPersonaName, uintptr(s))
+	v, err := theLib.call(funcType_Ptr_Ptr, flatAPI_ISteamFriends_GetPersonaName, uint64(s))
 	if err != nil {
 		panic(err)
 	}
@@ -351,7 +351,7 @@ func (s steamFriends) SetRichPresence(key, value string) bool {
 	cvalue := C.CString(value)
 	defer C.free(unsafe.Pointer(cvalue))
 
-	v, err := theLib.call(funcType_Bool_Ptr_Ptr_Ptr, flatAPI_ISteamFriends_SetRichPresence, uintptr(s), uintptr(unsafe.Pointer(ckey)), uintptr(unsafe.Pointer(cvalue)))
+	v, err := theLib.call(funcType_Bool_Ptr_Ptr_Ptr, flatAPI_ISteamFriends_SetRichPresence, uint64(s), uint64(uintptr(unsafe.Pointer(ckey))), uint64(uintptr(unsafe.Pointer(cvalue))))
 	if err != nil {
 		panic(err)
 	}
@@ -371,7 +371,7 @@ type steamInput C.uintptr_t
 
 func (s steamInput) GetConnectedControllers() []InputHandle_t {
 	var handles [_STEAM_INPUT_MAX_COUNT]InputHandle_t
-	v, err := theLib.call(funcType_Int32_Ptr_Ptr, flatAPI_ISteamInput_GetConnectedControllers, uintptr(s), uintptr(unsafe.Pointer(&handles[0])))
+	v, err := theLib.call(funcType_Int32_Ptr_Ptr, flatAPI_ISteamInput_GetConnectedControllers, uint64(s), uint64(uintptr(unsafe.Pointer(&handles[0]))))
 	if err != nil {
 		panic(err)
 	}
@@ -379,7 +379,7 @@ func (s steamInput) GetConnectedControllers() []InputHandle_t {
 }
 
 func (s steamInput) GetInputTypeForHandle(inputHandle InputHandle_t) ESteamInputType {
-	v, err := theLib.call(funcType_Int32_Ptr_Int64, flatAPI_ISteamInput_GetInputTypeForHandle, uintptr(s), uintptr(inputHandle))
+	v, err := theLib.call(funcType_Int32_Ptr_Int64, flatAPI_ISteamInput_GetInputTypeForHandle, uint64(s), uint64(inputHandle))
 	if err != nil {
 		panic(err)
 	}
@@ -387,11 +387,11 @@ func (s steamInput) GetInputTypeForHandle(inputHandle InputHandle_t) ESteamInput
 }
 
 func (s steamInput) Init(bExplicitlyCallRunFrame bool) bool {
-	var callRunFrame uintptr
+	var callRunFrame uint64
 	if bExplicitlyCallRunFrame {
 		callRunFrame = 1
 	}
-	v, err := theLib.call(funcType_Bool_Ptr_Bool, flatAPI_ISteamInput_Init, uintptr(s), callRunFrame)
+	v, err := theLib.call(funcType_Bool_Ptr_Bool, flatAPI_ISteamInput_Init, uint64(s), callRunFrame)
 	if err != nil {
 		panic(err)
 	}
@@ -399,7 +399,7 @@ func (s steamInput) Init(bExplicitlyCallRunFrame bool) bool {
 }
 
 func (s steamInput) RunFrame() {
-	if _, err := theLib.call(funcType_Void_Ptr_Bool, flatAPI_ISteamInput_RunFrame, uintptr(s), 0); err != nil {
+	if _, err := theLib.call(funcType_Void_Ptr_Bool, flatAPI_ISteamInput_RunFrame, uint64(s), 0); err != nil {
 		panic(err)
 	}
 }
@@ -420,7 +420,7 @@ func (s steamRemoteStorage) FileWrite(file string, data []byte) bool {
 
 	defer runtime.KeepAlive(data)
 
-	v, err := theLib.call(funcType_Bool_Ptr_Ptr_Ptr_Int32, flatAPI_ISteamRemoteStorage_FileWrite, uintptr(s), uintptr(unsafe.Pointer(cfile)), uintptr(unsafe.Pointer(&data[0])), uintptr(len(data)))
+	v, err := theLib.call(funcType_Bool_Ptr_Ptr_Ptr_Int32, flatAPI_ISteamRemoteStorage_FileWrite, uint64(s), uint64(uintptr(unsafe.Pointer(cfile))), uint64(uintptr(unsafe.Pointer(&data[0]))), uint64(len(data)))
 	if err != nil {
 		panic(err)
 	}
@@ -433,7 +433,7 @@ func (s steamRemoteStorage) FileRead(file string, data []byte) int32 {
 
 	defer runtime.KeepAlive(data)
 
-	v, err := theLib.call(funcType_Int32_Ptr_Ptr_Ptr_Int32, flatAPI_ISteamRemoteStorage_FileRead, uintptr(s), uintptr(unsafe.Pointer(cfile)), uintptr(unsafe.Pointer(&data[0])), uintptr(len(data)))
+	v, err := theLib.call(funcType_Int32_Ptr_Ptr_Ptr_Int32, flatAPI_ISteamRemoteStorage_FileRead, uint64(s), uint64(uintptr(unsafe.Pointer(cfile))), uint64(uintptr(unsafe.Pointer(&data[0]))), uint64(len(data)))
 	if err != nil {
 		panic(err)
 	}
@@ -444,7 +444,7 @@ func (s steamRemoteStorage) FileDelete(file string) bool {
 	cfile := C.CString(file)
 	defer C.free(unsafe.Pointer(cfile))
 
-	v, err := theLib.call(funcType_Bool_Ptr_Ptr, flatAPI_ISteamRemoteStorage_FileDelete, uintptr(s), uintptr(unsafe.Pointer(cfile)))
+	v, err := theLib.call(funcType_Bool_Ptr_Ptr, flatAPI_ISteamRemoteStorage_FileDelete, uint64(s), uint64(uintptr(unsafe.Pointer(cfile))))
 	if err != nil {
 		panic(err)
 	}
@@ -455,7 +455,7 @@ func (s steamRemoteStorage) GetFileSize(file string) int32 {
 	cfile := C.CString(file)
 	defer C.free(unsafe.Pointer(cfile))
 
-	v, err := theLib.call(funcType_Int32_Ptr, flatAPI_ISteamRemoteStorage_GetFileSize, uintptr(s), uintptr(unsafe.Pointer(cfile)))
+	v, err := theLib.call(funcType_Int32_Ptr, flatAPI_ISteamRemoteStorage_GetFileSize, uint64(s), uint64(uintptr(unsafe.Pointer(cfile))))
 	if err != nil {
 		panic(err)
 	}
@@ -473,7 +473,7 @@ func SteamUser() ISteamUser {
 type steamUser C.uintptr_t
 
 func (s steamUser) GetSteamID() CSteamID {
-	v, err := theLib.call(funcType_Int64_Ptr, flatAPI_ISteamUser_GetSteamID, uintptr(s))
+	v, err := theLib.call(funcType_Int64_Ptr, flatAPI_ISteamUser_GetSteamID, uint64(s))
 	if err != nil {
 		panic(err)
 	}
@@ -494,7 +494,7 @@ func (s steamUserStats) GetAchievement(name string) (achieved, success bool) {
 	cname := C.CString(name)
 	defer C.free(unsafe.Pointer(cname))
 
-	v, err := theLib.call(funcType_Bool_Ptr_Ptr_Ptr, flatAPI_ISteamUserStats_GetAchievement, uintptr(s), uintptr(unsafe.Pointer(cname)), uintptr(unsafe.Pointer(&achieved)))
+	v, err := theLib.call(funcType_Bool_Ptr_Ptr_Ptr, flatAPI_ISteamUserStats_GetAchievement, uint64(s), uint64(uintptr(unsafe.Pointer(cname))), uint64(uintptr(unsafe.Pointer(&achieved))))
 	if err != nil {
 		panic(err)
 	}
@@ -507,7 +507,7 @@ func (s steamUserStats) SetAchievement(name string) bool {
 	cname := C.CString(name)
 	defer C.free(unsafe.Pointer(cname))
 
-	v, err := theLib.call(funcType_Bool_Ptr_Ptr, flatAPI_ISteamUserStats_SetAchievement, uintptr(s), uintptr(unsafe.Pointer(cname)))
+	v, err := theLib.call(funcType_Bool_Ptr_Ptr, flatAPI_ISteamUserStats_SetAchievement, uint64(s), uint64(uintptr(unsafe.Pointer(cname))))
 	if err != nil {
 		panic(err)
 	}
@@ -519,7 +519,7 @@ func (s steamUserStats) ClearAchievement(name string) bool {
 	cname := C.CString(name)
 	defer C.free(unsafe.Pointer(cname))
 
-	v, err := theLib.call(funcType_Bool_Ptr_Ptr, flatAPI_ISteamUserStats_ClearAchievement, uintptr(s), uintptr(unsafe.Pointer(cname)))
+	v, err := theLib.call(funcType_Bool_Ptr_Ptr, flatAPI_ISteamUserStats_ClearAchievement, uint64(s), uint64(uintptr(unsafe.Pointer(cname))))
 	if err != nil {
 		panic(err)
 	}
@@ -528,7 +528,7 @@ func (s steamUserStats) ClearAchievement(name string) bool {
 }
 
 func (s steamUserStats) StoreStats() bool {
-	v, err := theLib.call(funcType_Bool_Ptr, flatAPI_ISteamUserStats_StoreStats, uintptr(s))
+	v, err := theLib.call(funcType_Bool_Ptr, flatAPI_ISteamUserStats_StoreStats, uint64(s))
 	if err != nil {
 		panic(err)
 	}
@@ -547,7 +547,7 @@ func SteamUtils() ISteamUtils {
 type steamUtils C.uintptr_t
 
 func (s steamUtils) IsSteamRunningOnSteamDeck() bool {
-	v, err := theLib.call(funcType_Bool_Ptr, flatAPI_ISteamUtils_IsSteamRunningOnSteamDeck, uintptr(s))
+	v, err := theLib.call(funcType_Bool_Ptr, flatAPI_ISteamUtils_IsSteamRunningOnSteamDeck, uint64(s))
 	if err != nil {
 		panic(err)
 	}
@@ -555,7 +555,7 @@ func (s steamUtils) IsSteamRunningOnSteamDeck() bool {
 }
 
 func (s steamUtils) ShowFloatingGamepadTextInput(keyboardMode EFloatingGamepadTextInputMode, textFieldXPosition, textFieldYPosition, textFieldWidth, textFieldHeight int32) bool {
-	v, err := theLib.call(funcType_Bool_Ptr_Int32_Int32_Int32_Int32_Int32, flatAPI_ISteamUtils_ShowFloatingGamepadTextInput, uintptr(s), uintptr(keyboardMode), uintptr(textFieldXPosition), uintptr(textFieldYPosition), uintptr(textFieldWidth), uintptr(textFieldHeight))
+	v, err := theLib.call(funcType_Bool_Ptr_Int32_Int32_Int32_Int32_Int32, flatAPI_ISteamUtils_ShowFloatingGamepadTextInput, uint64(s), uint64(keyboardMode), uint64(textFieldXPosition), uint64(textFieldYPosition), uint64(textFieldWidth), uint64(textFieldHeight))
 	if err != nil {
 		panic(err)
 	}

--- a/steamworks_windows.go
+++ b/steamworks_windows.go
@@ -204,7 +204,20 @@ func (s steamInput) GetConnectedControllers() []InputHandle_t {
 }
 
 func (s steamInput) GetInputTypeForHandle(inputHandle InputHandle_t) ESteamInputType {
-	v, _, err := theDLL.call(flatAPI_ISteamInput_GetInputTypeForHandle, uintptr(s), uintptr(inputHandle))
+	var v uintptr
+	var err error
+
+	if is32Bit {
+		// On 32-bit Windows, we need to manually split the 64-bit value
+		// and pass it as two consecutive stack arguments
+		inputHandleLow := uintptr(uint32(inputHandle))
+		inputHandleHigh := uintptr(uint32(inputHandle >> 32))
+
+		v, _, err = theDLL.call(flatAPI_ISteamInput_GetInputTypeForHandle, uintptr(s), inputHandleLow, inputHandleHigh)
+	} else {
+		v, _, err = theDLL.call(flatAPI_ISteamInput_GetInputTypeForHandle, uintptr(s), uintptr(inputHandle))
+	}
+
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Currently the 64-bit InputHandle_t argument for ISteamInput.GetInputTypeForHandle() is getting truncated on 32-bit platforms due to cast to uintptr.

This changes go-steamworks to support passing or returning 64-bit values even on 32-bit platforms, to fix that bug.