### PR TITLE
fix(readme): init is error interface type not boolean

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ On Windows, copy one of these files on the working directory:
 package steamapi
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/hajimehoshi/go-steamworks"
@@ -32,7 +33,7 @@ func init() {
 		os.Exit(1)
 	}
 	if err := steamworks.Init(); err != nil {
-		panic("steamworks.Init failed")
+		panic(fmt.Sprintf("steamworks.Init failed: %v", err))
 	}
 }
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ func init() {
 	if steamworks.RestartAppIfNecessary(appID) {
 		os.Exit(1)
 	}
-	if !steamworks.Init() {
+	if err := steamworks.Init(); err != nil {
 		panic("steamworks.Init failed")
 	}
 }


### PR DESCRIPTION
Was experimenting with go steamworks package and noticed the documentation is out of date with the response type of steamworks.Init().

Also added .idea to gitignore for any JetBrains users contributing in the future.